### PR TITLE
Don't log Consul's stderr or stdout to syslog

### DIFF
--- a/templates/consul_systemd.service.j2
+++ b/templates/consul_systemd.service.j2
@@ -36,6 +36,8 @@ RestartSec={{ consul_systemd_restart_sec }}s
 Environment={{ var }}
 {% endfor %}
 LimitNOFILE={{ consul_systemd_limit_nofile }}
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Consul already has built-in syslogging. It also streams logs to
stdout/stderr. In systemd this then gets logged to syslog resulting in
duplicate logs.

The logs that come via systemd are also malformed (the severity isn't
correctly identified) so it makes sense to drop these in favour of the
native syslogged messages.

The downside is that startup messages sent to stout before Consul's
syslogging is initialised is missed. However this was also the case on
Trusty before systemd so it seems like a valid trade-off.